### PR TITLE
Unify yeastgenome URL

### DIFF
--- a/experimentA/idr0040-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0040-experimentA-bulkmap-config.yml
@@ -61,7 +61,8 @@ columns:
           include: yes
         - name: Comment [Gene Identifier 1]
           clientname: Gene Identifier URL
-          clientvalue: http://www.yeastgenome.org/locus/{{ value|urlencode }}
+          clientvalue: >
+            http://www.yeastgenome.org/locus/{{ value|urlencode }}/overview
           include: yes
         - name: Comment [Gene Symbol 1]
           clientname: Gene Symbol
@@ -75,7 +76,8 @@ columns:
           include: yes
         - name: Comment [Gene Identifier 2]
           clientname: Gene Identifier URL
-          clientvalue: http://www.yeastgenome.org/locus/{{ value|urlencode }}
+          clientvalue: >
+            http://www.yeastgenome.org/locus/{{ value|urlencode }}/overview
           include: yes
         - name: Comment [Gene Symbol 2]
           clientname: Gene Symbol

--- a/experimentA/idr0040-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0040-experimentA-bulkmap-config.yml
@@ -62,7 +62,7 @@ columns:
         - name: Comment [Gene Identifier 1]
           clientname: Gene Identifier URL
           clientvalue: >
-            http://www.yeastgenome.org/locus/{{ value|urlencode }}/overview
+            https://www.yeastgenome.org/locus/{{ value|urlencode }}
           include: yes
         - name: Comment [Gene Symbol 1]
           clientname: Gene Symbol
@@ -77,7 +77,7 @@ columns:
         - name: Comment [Gene Identifier 2]
           clientname: Gene Identifier URL
           clientvalue: >
-            http://www.yeastgenome.org/locus/{{ value|urlencode }}/overview
+            https://www.yeastgenome.org/locus/{{ value|urlencode }}
           include: yes
         - name: Comment [Gene Symbol 2]
           clientname: Gene Symbol


### PR DESCRIPTION
From current production IDR see `idr0040`

![Screen Shot 2019-12-05 at 16 34 29](https://user-images.githubusercontent.com/1355463/70254533-22c66680-177d-11ea-9ed4-c395242eeef6.png)

Genes of previous yeast studies (`idr0003`, `idr0004`, `idr0007`, `idr0011`) had been annotated to link to http://www.yeastgenome.org/locus/<GENE>/overview. Although this redirects, using a different creates an unnecessary key in the map annotation.

Proposing to unify the yeast gene maps for `prod72` and re-creating the map annotations of `idr0040` as well as `idr0067`

/cc @francesw